### PR TITLE
chore: 직원 enum 정리 및 Querydsl 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,8 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
+    implementation 'com.querydsl:querydsl-jpa'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jpa'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/hrbank/employee/Employee.java
+++ b/src/main/java/com/hrbank/employee/Employee.java
@@ -1,5 +1,6 @@
 package com.hrbank.employee;
 
+import com.hrbank.employee.enums.EmployeeStatus;
 import com.hrbank.file.File;
 import jakarta.persistence.*;
 

--- a/src/main/java/com/hrbank/employee/EmployeeController.java
+++ b/src/main/java/com/hrbank/employee/EmployeeController.java
@@ -1,14 +1,15 @@
 package com.hrbank.employee;
 
-import com.hrbank.employee.dto.EmployeeDistributionDto;
-import com.hrbank.employee.dto.EmployeeCreateRequest;
-import com.hrbank.employee.dto.EmployeeDto;
-import com.hrbank.employee.dto.EmployeeTrendDto;
+import com.hrbank.employee.dto.*;
+
 import java.time.LocalDate;
 import java.util.List;
 
-import com.hrbank.employee.dto.EmployeeUpdateRequest;
+import com.hrbank.employee.enums.EmployeeStatus;
+import com.hrbank.employee.enums.SortDirection;
+import com.hrbank.employee.enums.SortField;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.bind.DefaultValue;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -69,6 +70,28 @@ public class EmployeeController {
               .status(HttpStatus.NO_CONTENT)
               .build();
   }
+
+  @GetMapping
+  public ResponseEntity<CursorPageResponseEmployeeDto> getEmployeesByFilter(
+          // 검색 조건
+          @RequestParam(required = false) String nameOrEmail,
+          @RequestParam(required = false) String employeeNumber,
+          @RequestParam(required = false) String departmentName,
+          @RequestParam(required = false) String position,
+          @RequestParam(required = false) LocalDate hireDateFrom,
+          @RequestParam(required = false) LocalDate hireDateTo,
+          @RequestParam(required = false) EmployeeStatus status,
+          // 페이징, 커서
+          @RequestParam(required = false) Long idAfter,
+          @RequestParam(required = false) String cursor,
+          // 정렬, 크기
+          @RequestParam(defaultValue = "10") Integer size,
+          @RequestParam(defaultValue = "name") SortField sortField,
+          @RequestParam(defaultValue = "asc") SortDirection sortDirection
+  ) {
+
+  }
+
 
   @GetMapping("/stats/trend")
   public ResponseEntity<List<EmployeeTrendDto>> getCountByTrend(

--- a/src/main/java/com/hrbank/employee/EmployeeRepository.java
+++ b/src/main/java/com/hrbank/employee/EmployeeRepository.java
@@ -1,6 +1,8 @@
 package com.hrbank.employee;
 
 import java.time.LocalDate;
+
+import com.hrbank.employee.enums.EmployeeStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 

--- a/src/main/java/com/hrbank/employee/EmployeeService.java
+++ b/src/main/java/com/hrbank/employee/EmployeeService.java
@@ -4,6 +4,7 @@ import com.hrbank.employee.dto.EmployeeCreateRequest;
 import com.hrbank.employee.dto.EmployeeDistributionDto;
 import com.hrbank.employee.dto.EmployeeDto;
 import com.hrbank.employee.dto.EmployeeTrendDto;
+import com.hrbank.employee.enums.EmployeeStatus;
 import com.hrbank.employee.mapper.EmployeeMapper;
 import com.hrbank.file.File;
 import com.hrbank.file.FileService;

--- a/src/main/java/com/hrbank/employee/dto/CursorPageResponseEmployeeDto.java
+++ b/src/main/java/com/hrbank/employee/dto/CursorPageResponseEmployeeDto.java
@@ -1,0 +1,13 @@
+package com.hrbank.employee.dto;
+
+import java.util.List;
+
+public record CursorPageResponseEmployeeDto(
+        List<EmployeeDto> content,
+        String nextCursor,
+        Long nextIdAfter,
+        Integer size,
+        Long totalElements,
+        Boolean hasNext
+) {
+}

--- a/src/main/java/com/hrbank/employee/dto/EmployeeDto.java
+++ b/src/main/java/com/hrbank/employee/dto/EmployeeDto.java
@@ -1,6 +1,6 @@
 package com.hrbank.employee.dto;
 
-import com.hrbank.employee.EmployeeStatus;
+import com.hrbank.employee.enums.EmployeeStatus;
 
 import java.time.LocalDate;
 

--- a/src/main/java/com/hrbank/employee/dto/EmployeeUpdateRequest.java
+++ b/src/main/java/com/hrbank/employee/dto/EmployeeUpdateRequest.java
@@ -1,6 +1,6 @@
 package com.hrbank.employee.dto;
 
-import com.hrbank.employee.EmployeeStatus;
+import com.hrbank.employee.enums.EmployeeStatus;
 
 import java.time.LocalDate;
 

--- a/src/main/java/com/hrbank/employee/enums/EmployeeStatus.java
+++ b/src/main/java/com/hrbank/employee/enums/EmployeeStatus.java
@@ -1,4 +1,4 @@
-package com.hrbank.employee;
+package com.hrbank.employee.enums;
 
 public enum EmployeeStatus {
   ACTIVE,

--- a/src/main/java/com/hrbank/employee/enums/SortDirection.java
+++ b/src/main/java/com/hrbank/employee/enums/SortDirection.java
@@ -1,0 +1,6 @@
+package com.hrbank.employee.enums;
+
+public enum SortDirection {
+    asc,
+    desc
+}

--- a/src/main/java/com/hrbank/employee/enums/SortField.java
+++ b/src/main/java/com/hrbank/employee/enums/SortField.java
@@ -1,0 +1,7 @@
+package com.hrbank.employee.enums;
+
+public enum SortField {
+    name,
+    employeeNumber,
+    hireDate
+}


### PR DESCRIPTION
- 직원 목록 조회 시 사용되는 SortField, SortDirection enum 추가
- 직원 도메인 내 enum들을 enums 패키지로 이동 및 참조 경로 수정
- 동적 쿼리 구현을 위한 QueryDSL 의존성 추가

- 기능 로직 변경은 없습니다.